### PR TITLE
Add support for debian 8

### DIFF
--- a/vars/Debian_8.yml
+++ b/vars/Debian_8.yml
@@ -1,0 +1,2 @@
+---
+iptables_service: netfilter-persistent


### PR DESCRIPTION
```
# service iptables-persistent status
● iptables-persistent.service
   Loaded: not-found (Reason: No such file or directory)
   Active: inactive (dead)
```

iptables-persistent was repaced by netfilter-persistent since debian 8